### PR TITLE
Correct a typo in the exported json

### DIFF
--- a/src/QuizForm.js
+++ b/src/QuizForm.js
@@ -125,7 +125,7 @@ class QuizForm extends Component {
             label="Message for Correct Answer"
           />
           <Field
-            name={`${question}.messageForInorrectAnswer`}
+            name={`${question}.messageForIncorrectAnswer`}
             type="text"
             component={this.renderTextareaField}
             label="Message for Incorrect Answer"


### PR DESCRIPTION
Fix a simple typo in `Field` component name.
#3 